### PR TITLE
Fix link status not being set.

### DIFF
--- a/commands.cpp
+++ b/commands.cpp
@@ -360,6 +360,7 @@ bool cmd_get_lan_interface_settings(lan_interface_settings& lan_interface_settin
         lan_interface_settings.is_enabled   = lan_settings.Enabled;
         lan_interface_settings.dhcp_mode    = lan_settings.DhcpIpMode;
         lan_interface_settings.dhcp_enabled = lan_settings.DhcpEnabled;
+        lan_interface_settings.link_status  = lan_settings.LinkStatus;
 
         lan_interface_settings.ip_address.push_back((lan_settings.Ipv4Address >> 24) & 0xff);
         lan_interface_settings.ip_address.push_back((lan_settings.Ipv4Address >> 16) & 0xff);

--- a/info.cpp
+++ b/info.cpp
@@ -153,8 +153,6 @@ bool info_get_certificate_hashes()
 
 bool info_get_all()
 {
-    std::vector<std::string> tmp;
-
     bool status_ver  = info_get_version();
     bool status_bld  = info_get_build_number();
     bool status_sku  = info_get_sku();
@@ -239,6 +237,13 @@ bool info_get_remote_access_connection_status()
 bool info_get_lan_interface_settings()
 {
     lan_interface_settings tmp;
+
+    tmp.is_enabled = false;
+    tmp.link_status = false;
+    tmp.dhcp_enabled = false;
+    tmp.dhcp_mode = 0;
+    tmp.ip_address.clear();
+    tmp.mac_address.clear();
 
     if (!cmd_get_lan_interface_settings(tmp)) return false;
 


### PR DESCRIPTION
Set link status value. Previously, it was not being set. Also initialize LAN interface settings members.