### PR TITLE
ci: remove Jenkins chron

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,5 @@
 pipeline {
     agent none
-    triggers {cron '@daily'}
     options {
         buildDiscarder(logRotator(numToKeepStr: '5', daysToKeepStr: '30'))
         timestamps()


### PR DESCRIPTION
ci: remove Jenkins chron

Github Org will build on changes after it scans. Removing the forced daily build will save some unneeded builds.